### PR TITLE
Move errors to CliBase

### DIFF
--- a/exe/ros
+++ b/exe/ros
@@ -7,7 +7,7 @@ elsif ARGV[0]&.include? ':'
   require 'rake'
   tasks = ARGV.each_with_object([]) { |arg, tasks| tasks.append(arg) if arg.index(':') }
   args = ARGV.each_with_object([]) { |arg, args| args.append(arg) unless arg.index(':') }
-  Rake.load_rakefile('Rakefile') if File.exists?('Rakefile')
+  Rake.load_rakefile('Rakefile') if File.exist?('Rakefile')
   tasks.each { |task| Rake::Task[task].invoke(args) }
 else
   require 'bundler/setup'

--- a/lib/ros.rb
+++ b/lib/ros.rb
@@ -59,7 +59,7 @@ module Ros
         files.append("#{Ros.root}/config/#{type}s/#{Ros.env}.yml")
         if ENV['ROS_PROFILE']
           profile_file = "#{Ros.root}/config/#{type}s/#{Ros.env}-#{ENV['ROS_PROFILE']}.yml"
-          files.append(profile_file) if File.exists?(profile_file)
+          files.append(profile_file) if File.exist?(profile_file)
         end
       end
       Config.load_and_set_settings(files)
@@ -85,7 +85,7 @@ module Ros
     def root
       @root ||= (cwd = Dir.pwd
         while not cwd.eql?('/')
-          break Pathname.new(cwd) if File.exists?("#{cwd}/config/deployment.yml")
+          break Pathname.new(cwd) if File.exist?("#{cwd}/config/deployment.yml")
           cwd = File.expand_path('..', cwd)
         end)
     end

--- a/lib/ros/be/application/cli.rb
+++ b/lib/ros/be/application/cli.rb
@@ -219,7 +219,8 @@ module Ros
 
         def context(options = {})
           return @context if @context
-          raise Error, set_color("ERROR: Not a Ros project", :red) if Ros.root.nil?
+          raise Error, set_color('ERROR: Not a Ros project', :red) if Ros.root.nil?
+
           require "ros/be/application/cli/#{infra_x.cluster_type}"
           @context = Ros::Be::Application.const_get(infra_x.cluster_type.capitalize).new(options)
           @context

--- a/lib/ros/be/application/cli.rb
+++ b/lib/ros/be/application/cli.rb
@@ -206,12 +206,12 @@ module Ros
             %x(git clone git@github.com:rails-on-services/ros.git) unless ros_repo
             require 'ros/main/env/generator'
             environments.each do |env|
-              Ros::Main::Env::Generator.new([env]).invoke_all if not File.exists?("#{Ros.environments_dir}/#{env}.yml")
+              Ros::Main::Env::Generator.new([env]).invoke_all if not File.exist?("#{Ros.environments_dir}/#{env}.yml")
             end
           else
             STDOUT.puts "ros repo: #{ros_repo ? 'ok' : 'missing'}"
             env_ok = environments.each do |env|
-              break false if not File.exists?("#{Ros.environments_dir}/#{env}.yml")
+              break false if not File.exist?("#{Ros.environments_dir}/#{env}.yml")
             end
             STDOUT.puts "environment configuration: #{env_ok ? 'ok' : 'missing'}"
           end

--- a/lib/ros/be/application/cli/generate.rb
+++ b/lib/ros/be/application/cli/generate.rb
@@ -6,6 +6,7 @@ module Ros
     module Application
       class GenerateCli < Thor
         include CliBase
+
         check_unknown_options!
         class_option :v, type: :boolean, default: false, desc: 'verbose output'
         class_option :n, type: :boolean, default: false, desc: "run but don't execute action"

--- a/lib/ros/be/application/cli/instance.rb
+++ b/lib/ros/be/application/cli/instance.rb
@@ -59,7 +59,7 @@ module Ros
 
         def get_credentials
           file = "#{Ros.is_ros? ? '' : 'ros/'}services/iam/tmp/#{application.current_feature_set}/credentials.json"
-          unless File.exists?(file)
+          unless File.exist?(file)
             errors.add(:get_credentials, "file not found: #{file}")
             return
           end
@@ -155,8 +155,8 @@ module Ros
         def database_check(name, config)
           prefix = config.ros ? 'app:' : ''
           migration_file = "#{application.compose_dir}/#{name}-migrated"
-          return true if File.exists?(migration_file) unless options.seed
-          FileUtils.rm(migration_file) if File.exists?(migration_file)
+          return true if File.exist?(migration_file) unless options.seed
+          FileUtils.rm(migration_file) if File.exist?(migration_file)
           if success = compose(:seed, "run --rm #{name} rails #{prefix}ros:db:reset:seed")
             FileUtils.touch(migration_file)
             if name.eql?('iam')

--- a/lib/ros/be/application/cli/instance.rb
+++ b/lib/ros/be/application/cli/instance.rb
@@ -5,11 +5,10 @@ module Ros
     module Application
       class Instance
         include CliBase
-        attr_accessor :services, :errors
+        attr_accessor :services
 
         def initialize(options = {})
           @options = options
-          @errors = Ros::Errors.new
         end
 
         def cmd(services)

--- a/lib/ros/be/application/cli/kubernetes.rb
+++ b/lib/ros/be/application/cli/kubernetes.rb
@@ -5,11 +5,10 @@ module Ros
     module Application
       class Kubernetes
         include CliBase
-        attr_accessor :services, :errors
+        attr_accessor :services
 
         def initialize(options = {})
           @options = options
-          @errors = Ros::Errors.new
         end
 
         def cmd(services)

--- a/lib/ros/be/application/cli_base.rb
+++ b/lib/ros/be/application/cli_base.rb
@@ -12,10 +12,21 @@ module Ros
         include Ros::CliBase
         attr_accessor :options
 
-        def infra; Ros::Be::Infra::Model end
-        def cluster; Ros::Be::Infra::Cluster::Model end
-        def application; Ros::Be::Application::Model end
-        def platform ; Ros::Be::Application::Platform::Model end
+        def infra
+          Ros::Be::Infra::Model
+        end
+
+        def cluster
+          Ros::Be::Infra::Cluster::Model
+        end
+
+        def application
+          Ros::Be::Application::Model
+        end
+
+        def platform
+          Ros::Be::Application::Platform::Model
+        end
 
         def generate_config
           silence_output do
@@ -100,7 +111,6 @@ module Ros
           show_endpoint
         end
 
-
         def show_endpoint
           STDOUT.puts "\n*** Services available at #{application.api_uri} ***"
           STDOUT.puts "*** API Docs available at [TO IMPLEMENT] ***\n\n"
@@ -108,7 +118,7 @@ module Ros
 
         def credentials
           switch!
-          get_credentials if not File.exists?(creds_file)
+          get_credentials if not File.exist?(creds_file)
           generate_config if stale_config
           postman = JSON.parse(json.each_with_object([]) { |j, a| a.append(Credential.new(j).to_postman) }.to_json)
           envs = json.each_with_object([]) { |j, a| a.append(Credential.new(j).to_env) }
@@ -123,7 +133,7 @@ module Ros
         end
 
         def json
-          @json ||= File.exists?(creds_file) ? JSON.parse(File.read(creds_file)) : []
+          @json ||= File.exist?(creds_file) ? JSON.parse(File.read(creds_file)) : []
         end
 
         def creds_file; @creds_file ||= "#{runtime_dir}/platform/credentials.json" end
@@ -147,7 +157,8 @@ module Ros
         # TODO: ros generate:docs:erd
         # NOTE: if these are cli commands then can take one or more services
         def publish_env_credentials
-          return unless File.exists?(creds_file)
+          return unless File.exist?(creds_file)
+
           content = json.each_with_object([]) { |j, a| a.append(Credential.new(j).to_env) }.join("\n")
           File.open("#{application.deploy_path}/platform/credentials.env", 'w') { |f| f.puts "#{content}\n" }
         end
@@ -159,7 +170,7 @@ module Ros
           FileUtils.mkdir_p(documents_dir)
           services.each do |service|
             exec(service, 'rails app:ros:erd:generate')
-            if File.exists?("services/#{service}/spec/dummy/erd.pdf")
+            if File.exist?("services/#{service}/spec/dummy/erd.pdf")
               FileUtils.mv("services/#{service}/spec/dummy/erd.pdf", "#{documents_dir}/#{service}.erd")
             end
           end

--- a/lib/ros/be/application/platform/generator.rb
+++ b/lib/ros/be/application/platform/generator.rb
@@ -28,7 +28,7 @@ module Ros
           def env_files
             ary = []
             ary.append('../platform/platform.env')
-            ary.append('../platform/credentials.env') if File.exists?("#{deploy_path}/credentials.env")
+            ary.append('../platform/credentials.env') if File.exist?("#{deploy_path}/credentials.env")
             ary.append("../platform/#{name}.env") if has_envs
             ary
           end

--- a/lib/ros/be/application/platform/rails/service/app/initializers.rb
+++ b/lib/ros/be/application/platform/rails/service/app/initializers.rb
@@ -19,7 +19,7 @@ inject_into_file 'config/application.rb', after: ".api_only = true\n" do <<-RUBY
 
   initializer 'service.set_platform_config', before: 'ros_core.load_platform_config' do |app|
     settings_path = root.join('config/settings.yml')
-    Settings.prepend_source!(settings_path) if File.exists? settings_path
+    Settings.prepend_source!(settings_path) if File.exist? settings_path
     name = self.class.name.split('::').first.downcase
     Settings.prepend_source!({ service: { name: name, policy_name: name.capitalize } })
     app.config.hosts << name

--- a/lib/ros/be/application/platform/rails/service/plugin/templates/lib/%namespaced_name%/engine.rb.tt
+++ b/lib/ros/be/application/platform/rails/service/plugin/templates/lib/%namespaced_name%/engine.rb.tt
@@ -11,7 +11,7 @@
 
     initializer 'service.set_platform_config', before: 'ros_core.load_platform_config' do |_app|
       settings_path = root.join('config/settings.yml')
-      Settings.prepend_source!(settings_path) if File.exists? settings_path
+      Settings.prepend_source!(settings_path) if File.exist? settings_path
       name = self.class.parent.name.demodulize.underscore
       Settings.prepend_source!({ service: { name: name, policy_name: name.capitalize } })
     end\n

--- a/lib/ros/be/infra/cli.rb
+++ b/lib/ros/be/infra/cli.rb
@@ -9,6 +9,7 @@ module Ros
     module Infra
       class Cli < Thor
         include CliBase
+
         check_unknown_options!
         class_option :v, type: :boolean, default: false, desc: 'verbose output'
         class_option :n, type: :boolean, default: false, desc: "run but don't execute action"
@@ -71,7 +72,7 @@ module Ros
         end
 
         def show_json
-          if File.exists?('output.json')
+          if File.exist?('output.json')
             json = JSON.parse(File.read('output.json'))
             # TODO: This will need to change for two things:
             # 1. when deploying to cluster these values will be different

--- a/lib/ros/cli_base.rb
+++ b/lib/ros/cli_base.rb
@@ -18,7 +18,12 @@ module Ros
   end
 
   module CliBase
-    attr_accessor :options
+    attr_accessor :options, :errors
+
+    def initialize(*args)
+      @errors = Ros::Errors.new
+    end
+
     def test_for_project
       raise Error, set_color("ERROR: Not a Ros project", :red) if Ros.root.nil?
     end

--- a/lib/ros/cli_base.rb
+++ b/lib/ros/cli_base.rb
@@ -20,31 +20,34 @@ module Ros
   module CliBase
     attr_accessor :options, :errors
 
-    def initialize(*args)
+    def initialize(*_args)
+      super
       @errors = Ros::Errors.new
     end
 
     def test_for_project
-      raise Error, set_color("ERROR: Not a Ros project", :red) if Ros.root.nil?
+      raise Error, set_color('ERROR: Not a Ros project', :red) if Ros.root.nil?
     end
 
     def system_cmd(label = :unknown, env = {}, cmd)
       puts cmd if options.v
       return if options.n
+
       result = system(env, cmd)
       errors.add(label) unless result
       result
     end
 
     def exit
-      STDOUT.puts(errors.messages.map{|(k,v)| "#{k}=#{v}"}) unless errors.size.zero?
+      STDOUT.puts(errors.messages.map{ |(k, v)| "#{k}=#{v}" }) unless errors.size.zero?
       Kernel.exit(errors.size)
     end
 
     # TODO: the namespace needs to be configurable; don't assume 'be'
     def stale_config
       return true if config_files.empty?
-      mtime = config_files.map{ |f| File.mtime(f) }.min
+
+      mtime = config_files.map { |f| File.mtime(f) }.min
       # Check config files
       Dir["#{Ros.root}/config/**/*.yml"].each { |f| return true if mtime < File.mtime(f) }
       # Check template files
@@ -59,6 +62,7 @@ module Ros
     end
 
     def config_files; raise NotImplementedError end
+
     def generate_config; raise NotImplementedError end
 
     def silence_output

--- a/lib/ros/main/env/generator.rb
+++ b/lib/ros/main/env/generator.rb
@@ -15,7 +15,7 @@ module Ros
           FileUtils.mkdir_p(Ros.environments_dir)
           # If an encrypted version of the environment exists and a key is present
           # then decrypt and write the contents to config/environments
-          if File.exists?("#{Ros.deployments_dir}/#{name}.yml.enc")
+          if File.exist?("#{Ros.deployments_dir}/#{name}.yml.enc")
             if ENV['ROS_MASTER_KEY']
               system("ansible-vault decrypt #{Ros.deployments_dir}/#{name}.yml.enc --output #{Ros.environments_dir}/#{name}.yml")
               return
@@ -31,7 +31,7 @@ module Ros
           end
           # If a new environment has been generated and the encryption key is present then encrypt the file
           # to a location that will be saved in the repository
-          if not File.exists?("#{Ros.deployments_dir}/#{name}.yml.enc")
+          if not File.exist?("#{Ros.deployments_dir}/#{name}.yml.enc")
             if ENV['ROS_MASTER_KEY']
               system("ansible-vault encrypt #{Ros.environments_dir}/#{name}.yml --output #{Ros.deployments_dir}/#{name}.yml.enc")
             else
@@ -43,7 +43,7 @@ module Ros
         # TODO: some other way to seed services on host with an env
         # This would be to write the same values as in the compose platform.env to
         # Ros.root/lib/core/config/environments/local.yml so core could load it
-        # What would normally be 
+        # What would normally be
         # def create_console_env
         #   return unless name.eql?('console')
         #   in_root do

--- a/lib/ros/postman/open_api.rb
+++ b/lib/ros/postman/open_api.rb
@@ -14,7 +14,7 @@ module Postman
     def target; "#{postman_dir}/#{file_name}" end
 
     def convert_to_postman
-      raise raise FileNotFoundException.new('File not found') unless File.exists?(source)
+      raise raise FileNotFoundException.new('File not found') unless File.exist?(source)
       FileUtils.mkdir_p(postman_dir)
       `openapi2postmanv2 -p -s #{source} -o #{target}`
     end


### PR DESCRIPTION
This mostly solves the problem of attribute errors being undefined when running: `ros be infra init -l`