### PR TITLE
Update to k8s services deployment. Add support for Jobs. Add kafka-connectors provision job template

### DIFF
--- a/lib/ros/be/application/cli/kubernetes.rb
+++ b/lib/ros/be/application/cli/kubernetes.rb
@@ -33,7 +33,26 @@ module Ros
 
         # TODO: Add ability for fail fast
         def up(services)
-          @services = services.empty? ? enabled_services : services
+          #@services = services.empty? ? enabled_services : services
+          @platform_services = []
+          @infra_services = []
+          services.each do |service|
+            @platform_services.push(service) if platform.components.keys.include?(service.to_sym)
+            @infra_services.push(service) if application.services.components.keys.include?(service.to_sym)
+          end
+
+          # No services specified - launch whole app stack
+          if @platform_services.empty? and @infra_services.empty?
+            @platform_services = enabled_services
+            @infra_services = application.services.components.keys
+          # app service(s) specified - launch app and ensure required infra services are up and running
+          elsif not @platform_services.empty? and @infra_services.empty?
+            @infra_services = application.services.components.keys
+          # infra service(s) specified - force update
+          elsif @platform_services.empty? and not @infra_services.empty?
+            @force_infra_update = true
+          end
+
           generate_config if stale_config
           if options.force or not system_cmd("kubectl get ns #{namespace}", kube_env)
             STDOUT.puts 'Forcing namespace create' if options.force
@@ -65,20 +84,31 @@ module Ros
 
         def deploy_services
           env_file = "#{services_root}/services.env"
-          sync_secret(env_file) if File.exist?(env_file)
-          enabled_application_services.each do |service|
+          sync_secret(env_file) if File.exists?(env_file)
+          @infra_services.each do |service|
             if service.eql?(:ingress)
               next true unless get_vs(name: :ingress).empty? or options.force
             else
-              next true if pod(name: service)
+              next if pod(name: service) unless @force_infra_update
             end
             env_file = "#{services_root}/#{service}.env"
             sync_secret(env_file) if File.exist?(env_file)
             service_file = "#{service}.yml"
             Dir.chdir(services_root) do
-              run_cmd = options.build ? 'run' : 'deploy'
-              skaffold("#{run_cmd} -f #{service_file}")
+              base_cmd = options.build ? 'run' : 'deploy'
+              force = @force_infra_update ? '--force' : ''
+              skaffold("#{base_cmd} #{force} -f #{service_file}")
               errors.add("skaffold_#{run_cmd}", stderr) if exit_code.positive?
+            end
+            deploy_jobs(service)
+          end
+        end
+
+        def deploy_jobs(service)
+          if File.directory?("#{services_root}/jobs/#{service}")
+            Dir.glob("#{services_root}/jobs/#{service}/*.yaml") do |job_file|
+              kube_cmd = "apply -f #{job_file} --force"
+              kubectl(kube_cmd)
             end
           end
         end
@@ -99,9 +129,8 @@ module Ros
 
         def deploy_platform
           update_platform_env
-          services.each do |service|
-            next true unless platform.components.keys.include?(service.to_sym)
-
+          @platform_services.each do |service|
+            #next unless platform.components.keys.include?(service.to_sym)
             env_file = "#{platform_root}/#{service}.env"
             sync_secret(env_file) if File.exist?(env_file)
             service_file = "#{platform_root}/#{service}.yml"

--- a/lib/ros/be/application/services/templates/jobs/kafka-connect/connector-provision-job.yml.erb
+++ b/lib/ros/be/application/services/templates/jobs/kafka-connect/connector-provision-job.yml.erb
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kafka-connect-connector-provision
+spec:
+  template:
+    metadata:
+      name: kafka-connect-connector-provision
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+        <% @service.kafka_connect.config.connectors.each do |connector| -%>
+        - image: gcr.io/cloud-builders/curl
+          name: <%= connector[0] %>
+          command:
+            - curl
+            - -X
+            - PUT
+            - http://kafka-connect:8083/connectors/<%= connector[0] %>/config
+            - -H
+            - "Content-Type: application/json"
+            - -H
+            - "Accept: application/json"
+            - -d
+            - >
+              {
+                "connector.class": <% if connector[1].type == 'bigquery' -%>"com.wepay.kafka.connect.bigquery.BigQuerySinkConnector",
+                <%# elsif connector[1].type == 'foo' -%>
+                <%# elsif connector[1].type == 'blah' -%><% end -%>
+                "autoUpdateSchemas": "false",
+                "bigQueryMessageTimePartitioning": "false",
+                "autoCreateTables": "true",
+                "sanitizeTopics": "true",
+                "tasks.max": "<%= connector[1].tasks ? connector[1].tasks : 2 %>",
+                "topics": "<%= connector[1].topics %>",
+                "schemaRegistryLocation": "http://kafka-schema-registry:8081",
+                "topicsToTables": "(\\w+)\\.(\\w+)=$1_$2",
+                "project": "<%= connector[1].project %>",
+                "datasets": ".*=<%= connector[1].dataset %>",
+                "keyfile": "/etc/google/auth/application_default_credentials.json",
+                "schemaRetriever": <% if connector[1].type == 'bigquery' -%>"com.wepay.kafka.connect.bigquery.schemaregistry.schemaretriever.SchemaRegistrySchemaRetriever",
+                <%# elsif connector[1].type == 'foo' -%>
+                <%# elsif connector[1].type == 'blah' -%><% end -%>
+                "key.converter": "org.apache.kafka.connect.storage.StringConverter"
+              }
+        <% end -%>
+      containers:
+        - image: busybox:latest
+          name: echo
+          command: ['sh', '-c', 'echo Connectors created. Check above logs!']

--- a/lib/ros/main/env/generator.rb
+++ b/lib/ros/main/env/generator.rb
@@ -15,7 +15,7 @@ module Ros
           FileUtils.mkdir_p(Ros.environments_dir)
           # If an encrypted version of the environment exists and a key is present
           # then decrypt and write the contents to config/environments
-          if File.exist?("#{Ros.deployments_dir}/big_query_credentials.json.enc") and ENV['ROS_MASTER_KEY']
+          if File.exists?("#{Ros.deployments_dir}/big_query_credentials.json.enc") and ENV['ROS_MASTER_KEY']
             system("ansible-vault decrypt #{Ros.deployments_dir}/big_query_credentials.json.enc --output #{Ros.environments_dir}/big_query_credentials.json")
           end
           if File.exist?("#{Ros.deployments_dir}/#{name}.yml.enc")


### PR DESCRIPTION
Hi Guys, 

This pull request is adding support for k8s Jobs. Kafka-connect connectors provisioning job is added as a first example.
Job templates are to be placed in services/templates/jobs/$service_name/ folder.

Another thing I've tried to address with this pull request:
With current implementation there is no way to update running infra service. If service is already running and has correct name labels assigned - it just silently skipped. I.e. `ros be up kafka` will do nothing if kafka already running.

Firstly I thought just to add `option.force`, but it also triggers force update for other resources, that may not be required.

So I tried to separate application services (platform and core) from infra services, accordingly to their declaration in config files. And implement unbreaking change that works as follows:

1. Launch whole platform as per config files `ros be up`. Will behaves as usual - launch all the app services and check that infra services running, launch if not
2. Launch single app service `ros be up iam`. Same as above - launch iam and check that infra services running, launch if not
3. Launch infra service `ros be up kafka`. This will ONLY apply `skaffolld deploy --force=true -f kafka.yml`. If any immutable parameters changed - recourse will be re-created. That's should be the only change from current implementation.

Duan, please let me know if that does make sense for you?
  
