### PR TITLE
Refactor ros init

### DIFF
--- a/lib/ros/be/infra/cli.rb
+++ b/lib/ros/be/infra/cli.rb
@@ -11,7 +11,7 @@ module Ros
         include CliBase
 
         check_unknown_options!
-        class_option :v, type: :boolean, default: false, desc: 'verbose output'
+        class_option :v, type: :boolean, default: true, desc: 'verbose output'
         class_option :n, type: :boolean, default: false, desc: "run but don't execute action"
 
         desc 'init', 'Initialize the cluster'

--- a/lib/ros/be/infra/cluster/generator.rb
+++ b/lib/ros/be/infra/cluster/generator.rb
@@ -30,7 +30,7 @@ module Ros
                 STDOUT.puts "missing #{credentials_file}"
                 return
               end
-              infra.config.cluster.aws_profile.nil? || ENV['AWS_PROFILE'] ? profile = "" : profile = "--profile #{infra.config.cluster.aws_profile}"
+              infra.config.cluster.aws_profile.nil? || ENV['AWS_PROFILE'] || ENV['AWS_DEFAULT_PROFILE'] ? profile = "" : profile = "--profile #{infra.config.cluster.aws_profile}"
               cmd_string = "aws eks update-kubeconfig --name #{name} #{profile}"
               cmd_string = "#{cmd_string} --role-arn arn:aws:iam::#{provider.account_id}:role/#{provider.cluster.role_name}" if cli.options.long
               cli.system_cmd(cmd_string)

--- a/lib/ros/be/infra/files/terraform/aws/eks-cluster/main.tf
+++ b/lib/ros/be/infra/files/terraform/aws/eks-cluster/main.tf
@@ -42,6 +42,7 @@ module "eks" {
   manage_aws_auth    = true
   write_kubeconfig   = true
   config_output_path = "./"
+  kubeconfig_name    = var.cluster_name
 
   kubeconfig_aws_authenticator_env_variables = {
     AWS_PROFILE = var.aws_profile
@@ -113,7 +114,7 @@ resource "aws_iam_role_policy_attachment" "eks-worker-external-dns" {
 }
 
 resource "null_resource" "k8s-tiller-rbac" {
-  depends_on = [module.eks]
+  #depends_on = [module.eks]
 
   provisioner "local-exec" {
     working_dir = path.module

--- a/lib/ros/be/infra/templates/terraform/aws/kubernetes.tf.erb
+++ b/lib/ros/be/infra/templates/terraform/aws/kubernetes.tf.erb
@@ -62,7 +62,7 @@ locals {
   accelerator_name                    = "<%= infra.components.globalaccelerator&.config&.name.nil? ? infra.config.cluster.name : infra.components.globalaccelerator.config.name %>"
   iam_name                            = "<%= infra.components.iam&.config&.name.nil? ? infra.config.cluster.name : infra.components.iam.config.name %>"
   tags                                = var.tags
-  domain_name                         = "<%= infra.dns.sub_domain %><%= infra.dns.sub_domain.nil? ? "" : "."%><%= infra.dns.root_domain %>"
+  domain_name                         = "<%= infra.config.cluster.dns.subdomain %><%= infra.config.cluster.dns.subdomain.nil? ? "" : "."%><%= infra.config.cluster.dns.domain %>"
 }
 
 # VPC
@@ -131,8 +131,8 @@ module "eks-cluster" {
 
 module "route53" {
   source                         = "./aws/route53"
-  root_domain                    = "<%= infra.dns.root_domain %>"
-  sub_domain                     = "<%= infra.dns.sub_domain %>"
+  root_domain                    = "<%= infra.config.cluster.dns.domain %>"
+  sub_domain                     = "<%= infra.config.cluster.dns.subdomain.nil? ? "" : infra.config.cluster.dns.subdomain %>"
   root_domain_managed_in_route53 = <%= infra.dns.root_domain_managed_in_route53 ? true : false %>
 }
 

--- a/lib/ros/be/infra/templates/terraform/aws/kubernetes.tf.erb
+++ b/lib/ros/be/infra/templates/terraform/aws/kubernetes.tf.erb
@@ -62,7 +62,7 @@ locals {
   accelerator_name                    = "<%= infra.components.globalaccelerator&.config&.name.nil? ? infra.config.cluster.name : infra.components.globalaccelerator.config.name %>"
   iam_name                            = "<%= infra.components.iam&.config&.name.nil? ? infra.config.cluster.name : infra.components.iam.config.name %>"
   tags                                = var.tags
-  domain_name                         = "<%= infra.config.cluster.dns.subdomain %><%= infra.config.cluster.dns.subdomain.nil? ? "" : "."%><%= infra.config.cluster.dns.domain %>"
+  domain_name                         = "<%= infra.dns.sub_domain %><%= infra.dns.sub_domain.nil? ? "" : "."%><%= infra.dns.root_domain %>"
 }
 
 # VPC
@@ -131,8 +131,8 @@ module "eks-cluster" {
 
 module "route53" {
   source                         = "./aws/route53"
-  root_domain                    = "<%= infra.config.cluster.dns.domain %>"
-  sub_domain                     = "<%= infra.config.cluster.dns.subdomain.nil? ? "" : infra.config.cluster.dns.subdomain %>"
+  root_domain                    = "<%= infra.dns.root_domain %>"
+  sub_domain                     = "<%= infra.dns.sub_domain %>"
   root_domain_managed_in_route53 = <%= infra.dns.root_domain_managed_in_route53 ? true : false %>
 }
 


### PR DESCRIPTION
Hi Duan, 

This PR address following issues:
1. Fix `dns.(sub)domain` references in `kubernetes.erb.tf`

2. Temporary commented  null-resource `k8s-tiller-rbac` dependancy on eks module. It caused me circular dependancy with `module.eks-cluster.module.eks.aws_launch_configuration.workers` when I launched `ros be infra apply` on existing cluster and it planned to update worker nodes config (volumes 50G -> 100G). 
I'm not sure if this dependancy is necessary, as  `k8s-tiller-rbac` triggered when kubeconfig file is ready...Does that implies that cluster is ready as well??
I'll keep it in mind and have a closer look when launching cluster infra from scratch

3. `ros be infra init` updated to consider AWS profile when getting and updating user kubeconfig
Precedence as following:
a. ENV AWS_PROFILE if set
b. `infra.config.cluster.aws_profile` if set
c. default AWS profile