### PR TITLE
Devops enable external kafka

### DIFF
--- a/lib/ros/be/application/cli/kubernetes.rb
+++ b/lib/ros/be/application/cli/kubernetes.rb
@@ -67,7 +67,6 @@ module Ros
           elsif @platform_services.empty? and not @infra_services.empty?
             @force_infra_deploy = true
           end
-
           generate_config if stale_config
           if options.force or not system_cmd("kubectl get ns #{namespace}", kube_env)
             STDOUT.puts 'Forcing namespace create' if options.force

--- a/lib/ros/be/application/services/generator.rb
+++ b/lib/ros/be/application/services/generator.rb
@@ -62,7 +62,8 @@ module Ros
               kafka_brokers: cluster.infra.cluster_type.eql?('kubernetes') ? 'kafka:9092' : 'kafkastack:9092',
               # storage_name: "storage#{base_hostname.gsub('.', '-')}",
               current_feature_set: application.current_feature_set
-            })
+            }).merge!(application.components.services.components[:'fluentd'])
+            binding.pry
           end
 
           def cluster; Ros::Be::Infra::Cluster::Model end

--- a/lib/ros/be/application/services/generator.rb
+++ b/lib/ros/be/application/services/generator.rb
@@ -38,7 +38,11 @@ module Ros
           end
 
           def kafka_connect
-            @kafka_connect ||= application.components.services.components[:'kafka-connect']
+            @kafka_connect ||= application.components.services.components[:'kafka-connect'].config
+          end
+
+          def kafka_schema_registry
+            @kafka_schema_registry ||= application.components.services.components[:'kafka-schema-registry'].config
           end
 
           # def self.aws_environment

--- a/lib/ros/be/application/services/generator.rb
+++ b/lib/ros/be/application/services/generator.rb
@@ -56,11 +56,7 @@ module Ros
             @fluentd ||= Config::Options.new({
               header: cluster.infra.cluster_type.eql?('kubernetes') ? "configMaps:\n  ros.conf: |" : '',
               include_tcp_source: cluster.infra.cluster_type.eql?('kubernetes') ? false : true,
-              # log_tag: "#{api_hostname}.rack-traffic-log",
-              request_log_tag: "**.rack-traffic-log",
-              event_log_tag: "events-log.**",
               kafka_brokers: cluster.infra.cluster_type.eql?('kubernetes') ? 'kafka:9092' : 'kafkastack:9092',
-              # storage_name: "storage#{base_hostname.gsub('.', '-')}",
               current_feature_set: application.current_feature_set
             }).merge!(application.components.services.components[:'fluentd'])
             binding.pry

--- a/lib/ros/be/application/services/generator.rb
+++ b/lib/ros/be/application/services/generator.rb
@@ -51,15 +51,11 @@ module Ros
 
           # Configuration values for fluentd request logging config file
           def fluentd
-            binding.pry
-            # If type is kubernetes, then value of header is:
             @fluentd ||= Config::Options.new({
               header: cluster.infra.cluster_type.eql?('kubernetes') ? "configMaps:\n  ros.conf: |" : '',
               include_tcp_source: cluster.infra.cluster_type.eql?('kubernetes') ? false : true,
-              #kafka_brokers: cluster.infra.cluster_type.eql?('kubernetes') ? 'kafka:9092' : 'kafkastack:9092',
               current_feature_set: application.current_feature_set
-            }) #.merge!(application.components.services.components[:'fluentd'])
-            binding.pry
+            }).merge!((application.components.services.components[:'fluentd'].config).to_hash)
           end
 
           def cluster; Ros::Be::Infra::Cluster::Model end
@@ -102,7 +98,6 @@ module Ros
                   # skip if it exists as an instance method on this class as it will be invoked by thor automatically
                   next if respond_to?(File.basename(template_file).gsub('.', '_').chomp('_erb').to_sym)
                   destination_file = "#{destination_root}/#{deploy_path}/#{template_file.gsub("#{base_service_template_dir}/", '')}".chomp('.erb')
-                  binding.pry
                   template(template_file, destination_file)
                 end
               end

--- a/lib/ros/be/application/services/generator.rb
+++ b/lib/ros/be/application/services/generator.rb
@@ -51,14 +51,14 @@ module Ros
 
           # Configuration values for fluentd request logging config file
           def fluentd
+            binding.pry
             # If type is kubernetes, then value of header is:
-            # "configMaps:\n  rails-audit-log.conf: |"
             @fluentd ||= Config::Options.new({
               header: cluster.infra.cluster_type.eql?('kubernetes') ? "configMaps:\n  ros.conf: |" : '',
               include_tcp_source: cluster.infra.cluster_type.eql?('kubernetes') ? false : true,
-              kafka_brokers: cluster.infra.cluster_type.eql?('kubernetes') ? 'kafka:9092' : 'kafkastack:9092',
+              #kafka_brokers: cluster.infra.cluster_type.eql?('kubernetes') ? 'kafka:9092' : 'kafkastack:9092',
               current_feature_set: application.current_feature_set
-            }).merge!(application.components.services.components[:'fluentd'])
+            }) #.merge!(application.components.services.components[:'fluentd'])
             binding.pry
           end
 
@@ -102,6 +102,7 @@ module Ros
                   # skip if it exists as an instance method on this class as it will be invoked by thor automatically
                   next if respond_to?(File.basename(template_file).gsub('.', '_').chomp('_erb').to_sym)
                   destination_file = "#{destination_root}/#{deploy_path}/#{template_file.gsub("#{base_service_template_dir}/", '')}".chomp('.erb')
+                  binding.pry
                   template(template_file, destination_file)
                 end
               end

--- a/lib/ros/be/application/services/templates/jobs/kafka-connect/connector-provision-job.yml.erb
+++ b/lib/ros/be/application/services/templates/jobs/kafka-connect/connector-provision-job.yml.erb
@@ -11,7 +11,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       initContainers:
-        <% @service.kafka_connect.config.connectors.each do |connector| -%>
+        <% @service.kafka_connect.connectors.each do |connector| -%>
         - image: gcr.io/cloud-builders/curl
           name: <%= connector[0] %>
           command:

--- a/lib/ros/be/application/services/templates/services/fluentd/etc/config.d/ros.conf.erb
+++ b/lib/ros/be/application/services/templates/services/fluentd/etc/config.d/ros.conf.erb
@@ -41,6 +41,7 @@
       username <%= @service.fluentd.api_key %>
       password <%= @service.fluentd.api_secret%>
       ssl_ca_certs_from_system true
+      sasl_over_ssl true
       <%- end -%>
       headers_from_record { "ce_specversion":"$.specversion", 
                             "ce_type":"$.type", 

--- a/lib/ros/be/application/services/templates/services/fluentd/etc/config.d/ros.conf.erb
+++ b/lib/ros/be/application/services/templates/services/fluentd/etc/config.d/ros.conf.erb
@@ -1,10 +1,11 @@
 <%= @service.fluentd.header %>
-    <%- if @service.fluentd.include_tcp_source %>
+    <%- if @service.fluentd.include_tcp_source -%>
     <source>
       @type forward
       port 24224
     </source>
-    <%- end %>
+    
+    <%- end -%>
     <filter **.rack-traffic-log>
       @type record_modifier
       # write a temporary field _unix_time
@@ -36,6 +37,11 @@
       brokers <%= @service.fluentd.kafka_brokers %>      
       topic_key type
       message_key_key id  
+      <%- if @service.fluentd.api_key && @service.fluentd.api_secret -%>
+      username <%= @service.fluentd.api_key %>
+      password <%= @service.fluentd.api_secret%>
+      ssl_ca_certs_from_system true
+      <%- end -%>
       headers_from_record { "ce_specversion":"$.specversion", 
                             "ce_type":"$.type", 
                             "ce_source":"$.source", 

--- a/lib/ros/be/application/services/templates/services/fluentd/etc/config.d/ros.conf.erb
+++ b/lib/ros/be/application/services/templates/services/fluentd/etc/config.d/ros.conf.erb
@@ -1,11 +1,11 @@
 <%= @service.fluentd.header %>
-    <% if @service.fluentd.include_tcp_source %>
+    <%- if @service.fluentd.include_tcp_source %>
     <source>
       @type forward
       port 24224
     </source>
-    <% end %>
-    <filter <%= @service.fluentd.request_log_tag %>>
+    <%- end %>
+    <filter **.rack-traffic-log>
       @type record_modifier
       # write a temporary field _unix_time
       <record>
@@ -13,25 +13,25 @@
       </record>
     </filter>
 
-    <filter <%= @service.fluentd.request_log_tag %>>
+    <filter **.rack-traffic-log>
       @type record_transformer
       enable_ruby true
       renew_time_key _unix_time
       remove_keys _unix_time
     </filter>
 
-    <match <%= @service.fluentd.request_log_tag %>>
+    <match **.rack-traffic-log>
       @type kafka_buffered
       brokers <%= @service.fluentd.kafka_brokers %>
       default_topic http_request_log
     </match>
 
-    <filter <%= @service.fluentd.event_log_tag %>>
+    <filter events-log.**>
       @type base64_decode
       fields data
     </filter>
 
-    <match <%= @service.fluentd.event_log_tag %>>
+    <match events-log.**>
       @type kafka2  
       brokers <%= @service.fluentd.kafka_brokers %>      
       topic_key type

--- a/lib/ros/be/application/services/templates/skaffold/kafka-connect.yml.erb
+++ b/lib/ros/be/application/services/templates/skaffold/kafka-connect.yml.erb
@@ -45,24 +45,21 @@ deploy:
             sasl.mechanism: PLAIN
             request.timeout.ms: 20000
             retry.backoff.ms: 500
-            sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule \
-            required username="<%= @service.kafka_connect.api_key %>" password="<%= @service.kafka_connect.api_secret %>";
+            sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="<%= @service.kafka_connect.api_key %>" password="<%= @service.kafka_connect.api_secret %>";
             security.protocol: SASL_SSL
 
             consumer.ssl.endpoint.identification.algorithm: https
             consumer.sasl.mechanism: PLAIN
             consumer.request.timeout.ms: 20000
             consumer.retry.backoff.ms: 500
-            consumer.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule \
-            required username="<%= @service.kafka_connect.api_key %>" password="<%= @service.kafka_connect.api_secret %>";
+            consumer.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="<%= @service.kafka_connect.api_key %>" password="<%= @service.kafka_connect.api_secret %>";
             consumer.security.protocol: SASL_SSL
 
             producer.ssl.endpoint.identification.algorithm: https
             producer.sasl.mechanism: PLAIN
             producer.request.timeout.ms: 20000
             producer.retry.backoff.ms: 500
-            producer.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule \
-            required username="<%= @service.kafka_connect.api_key %>" password="<%= @service.kafka_connect.api_secret %>";
+            producer.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="<%= @service.kafka_connect.api_key %>" password="<%= @service.kafka_connect.api_secret %>";
             producer.security.protocol: SASL_SSL
 
           kafka:

--- a/lib/ros/be/application/services/templates/skaffold/kafka-connect.yml.erb
+++ b/lib/ros/be/application/services/templates/skaffold/kafka-connect.yml.erb
@@ -29,9 +29,6 @@ deploy:
             #Below is temporary. Until I find out why env var isn't properly set from cp-schema-registry.url
             CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: "http://kafka-schema-registry:8081"
 
-          kafka:
-            bootstrapServers: "PLAINTEXT://kafka:9092"
-
           configurationOverrides:
             plugin.path: /usr/share/java,/usr/share/confluent-hub-components
             key.converter: org.apache.kafka.connect.storage.StringConverter
@@ -42,6 +39,38 @@ deploy:
             config.storage.replication.factor: 1
             status.storage.replication.factor: 1
             offset.storage.replication.factor: 1
+
+          <%- if @service.kafka_connect.api_key && @service.kafka_connect.api_secret -%>
+            ssl.endpoint.identification.algorithm: https
+            sasl.mechanism: PLAIN
+            request.timeout.ms: 20000
+            retry.backoff.ms: 500
+            sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule \
+            required username="<%= @service.kafka_connect.api_key %>" password="<%= @service.kafka_connect.api_secret %>";
+            security.protocol: SASL_SSL
+
+            consumer.ssl.endpoint.identification.algorithm: https
+            consumer.sasl.mechanism: PLAIN
+            consumer.request.timeout.ms: 20000
+            consumer.retry.backoff.ms: 500
+            consumer.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule \
+            required username="<%= @service.kafka_connect.api_key %>" password="<%= @service.kafka_connect.api_secret %>";
+            consumer.security.protocol: SASL_SSL
+
+            producer.ssl.endpoint.identification.algorithm: https
+            producer.sasl.mechanism: PLAIN
+            producer.request.timeout.ms: 20000
+            producer.retry.backoff.ms: 500
+            producer.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule \
+            required username="<%= @service.kafka_connect.api_key %>" password="<%= @service.kafka_connect.api_secret %>";
+            producer.security.protocol: SASL_SSL
+
+          kafka:
+            bootstrapServers: "SASL_SSL://<%= @service.kafka_connect.kafka_brokers %>"
+          <%- else -%>
+          kafka:
+            bootstrapServers: "PLAINTEXT://<%= @service.kafka_connect.kafka_brokers %>"
+          <%- end -%>
 
           prometheus:
             jmx:

--- a/lib/ros/be/application/services/templates/skaffold/kafka-schema-registry.yml.erb
+++ b/lib/ros/be/application/services/templates/skaffold/kafka-schema-registry.yml.erb
@@ -14,7 +14,16 @@ deploy:
           podLabels:
             app.kubernetes.io/name: kafka-schema-registry
           kafka:
-            bootstrapServers: "PLAINTEXT://kafka-headless:9092"
+            <%- if @service.kafka_schema_registry.api_key && @service.kafka_schema_registry.api_secret -%>
+            bootstrapServers: "SASL_SSL://<%= @service.kafka_schema_registry.kafka_brokers %>"
+          configurationOverrides:
+            kafkastore.security.protocol: SASL_SSL
+            kafkastore.sasl.mechanism: PLAIN
+            kafkastore.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule \
+            required username="<%= @service.kafka_schema_registry.api_key %>" password="<%= @service.kafka_schema_registry.api_secret %>";
+            <%- else -%>
+            bootstrapServers: "PLAINTEXT://<%= @service.kafka_schema_registry.kafka_brokers %>"
+            <%- end -%>
           heapOptions: "-Xms1024M -Xmx1024M"
           prometheus:
             jmx:

--- a/lib/ros/be/application/services/templates/skaffold/kafka-schema-registry.yml.erb
+++ b/lib/ros/be/application/services/templates/skaffold/kafka-schema-registry.yml.erb
@@ -19,8 +19,7 @@ deploy:
           configurationOverrides:
             kafkastore.security.protocol: SASL_SSL
             kafkastore.sasl.mechanism: PLAIN
-            kafkastore.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule \
-            required username="<%= @service.kafka_schema_registry.api_key %>" password="<%= @service.kafka_schema_registry.api_secret %>";
+            kafkastore.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="<%= @service.kafka_schema_registry.api_key %>" password="<%= @service.kafka_schema_registry.api_secret %>";
             <%- else -%>
             bootstrapServers: "PLAINTEXT://<%= @service.kafka_schema_registry.kafka_brokers %>"
             <%- end -%>

--- a/lib/ros/main/env/generator.rb
+++ b/lib/ros/main/env/generator.rb
@@ -16,12 +16,20 @@ module Ros
           # If an encrypted version of the environment exists and a key is present
           # then decrypt and write the contents to config/environments
           if ENV['ROS_MASTER_KEY']
+            # TODO. This is ugly and temporary. We need generic way to decrypt and copy secrets to their destinations
+            if File.exists?("#{Ros.deployments_dir}/production-test.yml.enc")
+              system("ansible-vault decrypt #{Ros.deployments_dir}/production-test.yml.enc --output #{Ros.environments_dir}/production-test.yml")
+            end
+            if File.exists?("#{Ros.deployments_dir}/production-uat.yml.enc")
+              system("ansible-vault decrypt #{Ros.deployments_dir}/production-uat.yml.enc --output #{Ros.environments_dir}/production-uat.yml")
+            end
             if File.exists?("#{Ros.deployments_dir}/big_query_credentials.json.enc")
               system("ansible-vault decrypt #{Ros.deployments_dir}/big_query_credentials.json.enc --output #{Ros.environments_dir}/big_query_credentials.json")
             end
             if File.exists?("#{Ros.deployments_dir}/gcp_fluentd_logging_credentials.json.enc")
               system("ansible-vault decrypt #{Ros.deployments_dir}/gcp_fluentd_logging_credentials.json.enc --output #{Ros.environments_dir}/gcp_fluentd_logging_credentials.json")
             end
+
           end
           if File.exist?("#{Ros.deployments_dir}/#{name}.yml.enc")
             if ENV['ROS_MASTER_KEY']


### PR DESCRIPTION
Hi Duan, 

There are templates and ros-cli changes to support external kafka cluster.

You can test to launch services at uat cluster, but dont merge it to master yet. We have to carefully go through all the whistler deployments configs to check that all deployments have respective kafka URLs in config. As those aren't hardcoded in ros-cli or skaffold templates anymore.