### PR TITLE
[WHIS-22] Fix kafka connector provisioning job

### DIFF
--- a/lib/ros/be/application/services/files/helm-charts/cp-helm-charts/cp-kafka-connect/templates/deployment.yaml
+++ b/lib/ros/be/application/services/files/helm-charts/cp-helm-charts/cp-kafka-connect/templates/deployment.yaml
@@ -84,9 +84,9 @@ spec:
               value: {{ template "cp-kafka-connect.fullname" . }}-offset
             - name: CONNECT_STATUS_STORAGE_TOPIC
               value: {{ template "cp-kafka-connect.fullname" . }}-status
-            - name: CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
-              value: {{ template "cp-kafka-connect.cp-schema-registry.service-name" .}}
             - name: CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL
+              value: {{ template "cp-kafka-connect.cp-schema-registry.service-name" .}}
+            - name: CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
               value: {{ template "cp-kafka-connect.cp-schema-registry.service-name" .}}
             - name: KAFKA_HEAP_OPTS
               value: "{{ .Values.heapOptions }}"

--- a/lib/ros/be/application/services/templates/jobs/kafka-connect/connector-provision-job.yml.erb
+++ b/lib/ros/be/application/services/templates/jobs/kafka-connect/connector-provision-job.yml.erb
@@ -18,7 +18,7 @@ spec:
             - curl
             - -X
             - PUT
-            - http://kafka-connect:8083/connectors/<%= name %>/config
+            - http://kafka-connect-<%= @service.current_feature_set %>:8083/connectors/<%= name %>-<%= @service.current_feature_set %>/config
             - -H
             - "Content-Type: application/json"
             - -H

--- a/lib/ros/be/application/services/templates/skaffold/kafka-connect.yml.erb
+++ b/lib/ros/be/application/services/templates/skaffold/kafka-connect.yml.erb
@@ -13,6 +13,7 @@ deploy:
           imageTag: latest
           nameOverride: kafka-connect
           fullnameOverride: kafka-connect-<%= @service.current_feature_set %>
+          overrideGroupId: kafka-connect-<%= @service.current_feature_set %>
           podLabels:
             app.kubernetes.io/name: kafka-connect
           ## Kafka Connect JVM Heap Option

--- a/lib/ros/be/application/services/templates/skaffold/kafka-connect.yml.erb
+++ b/lib/ros/be/application/services/templates/skaffold/kafka-connect.yml.erb
@@ -26,10 +26,9 @@ deploy:
               memory: 1Gi
           ## Additional env variables
           customEnv:
-            CONNECT_LOG4J_LOGGERS: "com.wepay.kafka.connect.bigquery=DEBUG"
+            CONNECT_LOG4J_LOGGERS: "com.wepay.kafka.connect.bigquery=DEBUG,org.apache.kafka.connect.runtime.rest=DEBUG"
             CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN: "[%d] %p %X{connector.context}%m (%c:%L)%n"
-            #Below is temporary. Until I find out why env var isn't properly set from cp-schema-registry.url
-            CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: "http://kafka-schema-registry:8081"
+            CONNECT_LOG4J_ROOT_LOGLEVEL: "WARN"
 
           configurationOverrides:
             plugin.path: /usr/share/java,/usr/share/confluent-hub-components

--- a/lib/ros/be/application/services/templates/skaffold/kafka-schema-registry.yml.erb
+++ b/lib/ros/be/application/services/templates/skaffold/kafka-schema-registry.yml.erb
@@ -11,6 +11,7 @@ deploy:
           imageTag: 5.3.0
           replicaCount: 1
           fullnameOverride: kafka-schema-registry
+          overrideGroupId: kafka-schema-registry-<%= @service.current_feature_set %>
           podLabels:
             app.kubernetes.io/name: kafka-schema-registry
           kafka:


### PR DESCRIPTION
Hi Duan, 
The issue with kafka-connect connectors provisioning started at the time we got dev1 namespace launched. Two kafka-connect servers in different namespaces, but using same connector name. So their connectors groupId had the same value. That confused all instances of kafka-connect running in different namespaces, but working with same external confluent kafka cluster. I've added feature_set suffix to connector name. That fixed an issue.
I believe the same should be done for kafka topics as a part of [WHIS-24](https://perxtechnologies.atlassian.net/browse/WHIS-24).