### PR TITLE
[WHIS-44] Fix prometheus_exporter path for non-ros services

### DIFF
--- a/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
+++ b/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
@@ -86,8 +86,8 @@ profiles:
               <%- if environment.platform&.metrics&.enabled -%>
               enabled: true
               <%- if profile.eql?('server') -%>
-              command: ["bundle", "exec", "prometheus_exporter", "-a", "/home/rails/lib/core/lib/ros/prometheus_exporter/web_collector.rb"]
-              <%-end -%>
+              command: ["bundle", "exec", "prometheus_exporter", "-a", "/home/rails/<% unless @service.is_ros_service %>ros/<% end %>lib/core/lib/ros/prometheus_exporter/web_collector.rb"]
+              <%- end -%>
               <%- else -%>
               enabled: false
               <%- end -%>


### PR DESCRIPTION
Hi Duan,

There is a tiny fix for non-ros services prometheus_exporter path.
Tested that it generates correct skaffold files. You can safely merge it. But don't enable metrics collection yet. There is another issue I've reported to Rob.