### PR TITLE
Add kafka schema registry schemas create during bootstrap job

### DIFF
--- a/lib/ros/be/application/cli/kubernetes.rb
+++ b/lib/ros/be/application/cli/kubernetes.rb
@@ -131,7 +131,10 @@ module Ros
         end
 
         def deploy_gcp_bigquery_secret
-          return if kubectl("get secret gcp-jsonkey") unless options.force
+          if kubectl("get secret gcp-jsonkey")
+            return unless options.force
+            kubectl("delete secret gcp-jsonkey")
+          end
           secret = application.components.services.components[:'kafka-connect']&.config&.gcp_service_account_key
           kube_cmd = "create secret generic gcp-jsonkey --from-literal=application_default_credentials.json='#{secret}'"
           kubectl(kube_cmd)

--- a/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
+++ b/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
@@ -73,7 +73,7 @@ profiles:
             hook:
               upgradeMigration:
                 enabled: true
-                command: ["bundle", "exec", "rails", "<% if @service.is_ros_service %>app:<% end %>db:migrate"]
+                command: ["bundle", "exec", "rails", "<% if @service.is_ros_service %>app:<% end %>db:migrate"<% if services_components[:"kafka-schema-registry"]&.config&.enabled%>, "<% if @service.is_ros_service %>app:<% end %>ros:avro:register"<% end %>]
             <%- elsif profile.eql?('worker') -%>
             service:
               enabled: false

--- a/lib/ros/be/application/services/templates/jobs/kafka-connect/connector-provision-job.yml.erb
+++ b/lib/ros/be/application/services/templates/jobs/kafka-connect/connector-provision-job.yml.erb
@@ -28,7 +28,7 @@ spec:
               <%- if config.type == 'bigquery' -%>
               {
                 "connector.class": "com.wepay.kafka.connect.bigquery.BigQuerySinkConnector",
-                "autoUpdateSchemas": "false",
+                "autoUpdateSchemas": "true",
                 "bigQueryMessageTimePartitioning": "false",
                 "autoCreateTables": "true",
                 "sanitizeTopics": "true",


### PR DESCRIPTION
Hi Duan, 
Couple changes:
* Create avro schemas upon migration job run
* Allow to re-create gcp service account key if cli option `force`
* KAfka-connect set `autoUpdateSchemas = true`