### PR TITLE
[Chore] Remove rubocop from the commands being run with test

### DIFF
--- a/lib/ros/be/application/cli_base.rb
+++ b/lib/ros/be/application/cli_base.rb
@@ -51,7 +51,7 @@ module Ros
           is_ros = svc_config(service)&.config&.ros
           prefix = is_ros ? 'app:' : ''
           exec_dir = is_ros ? 'spec/dummy/' : ''
-          ['bundle exec rubocop', "rails #{prefix}db:test:prepare", "#{exec_dir}bin/spring rspec #{rspec_options}"]
+          ["rails #{prefix}db:test:prepare", "#{exec_dir}bin/spring rspec #{rspec_options}"]
         end
 
 


### PR DESCRIPTION
Currently when we run `ros be test` this will try to run rubocop for the ros project.

1. From a ros-cli perspective this should not be default behaviour because the choice of using rubocop should be made by each project development group
2. Running the rubocop within the service does not actually lint all our files because we are currently loading ros-core and ros-sdk as libs but hey are not linted individually.
3. Waiting for the images to be built to be able to run the lint is counter productive.
4. At most we could provide a separate command that would invoke rubocop directly without building the image, but that seems useless