### PR TITLE
[PW-2460] Add Sentry environment vars to platform services

### DIFF
--- a/lib/ros/be/application/platform/generator.rb
+++ b/lib/ros/be/application/platform/generator.rb
@@ -57,6 +57,8 @@ module Ros
           def secrets_files; environment ? [:platform, name.to_sym] : %i(platform) end
           def skaffold_version; Settings.components.be.config.skaffold_version end
           def compose_version; Settings.components.be.config.compose_version || '3.2' end
+          def ros_env; Ros.env end
+          def ros_profile; Ros.profile end
         end
 
         class Generator < Thor::Group

--- a/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
+++ b/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
@@ -36,6 +36,7 @@ profiles:
             replicaCount: <% if profile.eql?('scheduler') %>1<% else %>"{{.REPLICA_COUNT}}"<% end %>
             image.tag: "{{.IMAGE_TAG}}"
             image.repository: "{{.SKAFFOLD_DEFAULT_REPO}}/<%= @service.name %>"
+            app.env.SENTRY_RELEASE: "{{.IMAGE_TAG}}"
           overrides:
             podDisruptionBudget:
               minAvailable: 1
@@ -55,6 +56,8 @@ profiles:
             imagePullSecrets:
               - name: <%= @service.pull_secret %>
             app:
+              env:
+                SENTRY_ENVIRONMENT: <%= @service.ros_env %><%= @service.ros_profile.empty? ? '' : '-' + @service.ros_profile %><%= @service.current_feature_set == 'master' ? '' : '-' + @service.current_feature_set %>
               <%- if profile.eql?('server') -%>
               command: ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "-P", "/tmp/server.pid"]
               <%- elsif profile.eql?('worker') and @service.is_ros_service -%>


### PR DESCRIPTION
Example of generated env vars for uat master:
```
env | grep SEN
SENTRY_ENVIRONMENT=production-uat
SENTRY_RELEASE=0.1.0-development-9c66d4fe
SENTRY_DSN=https://<<censored>>@sentry.io/1819291
```