### PR TITLE
Fix platform secret creation by CI

### DIFF
--- a/lib/ros/be/application/cli/kubernetes.rb
+++ b/lib/ros/be/application/cli/kubernetes.rb
@@ -152,7 +152,7 @@ module Ros
         end
 
         def deploy_platform
-          update_platform_env
+          update_platform_env unless options.skip_infra
           @platform_services.each do |service|
             #next unless platform.components.keys.include?(service.to_sym)
             env_file = "#{platform_root}/#{service}.env"


### PR DESCRIPTION
Currently we have `platform.env` secret created/deleted in parallel by multiple CI containers. That gives us false negative build results when two or more containers trying to delete the secret at the same time.

Suggest to respect `--skip-infra` flag when updating platform secret, so secret create/delete will be handled by first CI container only. 