### PR TITLE
[PW-2493] Disable PDB for scheduler profile

### DIFF
--- a/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
+++ b/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
@@ -38,8 +38,10 @@ profiles:
             image.repository: "{{.SKAFFOLD_DEFAULT_REPO}}/<%= @service.name %>"
             app.env.SENTRY_RELEASE: "{{.IMAGE_TAG}}"
           overrides:
+            <%- unless profile.eql?('scheduler') %>
             podDisruptionBudget:
               minAvailable: 1
+            <%- end %>
             labels:
               # app.kubernetes.io/name: <%= @service.name %>
               app.kubernetes.io/component: <%= profile %>


### PR DESCRIPTION
Disable Pod Disruption Budget for `scheduler` profile.

Any PDBs that already been created will have to delete manually.