### PR TITLE
Reduce default resource requests by platform services

### DIFF
--- a/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
+++ b/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
@@ -108,8 +108,8 @@ profiles:
                 cpu: 1
                 memory: 2.5Gi
               requests:
-                cpu: 0.5
-                memory: 2Gi
+                cpu: 200m
+                memory: 1Gi
             affinity:
               nodeAffinity:
                 preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Reduce default resource requests by platform services
Next step would be to set resource requests by environment and by service in config file.