### PR TITLE
rake: 12 -> 13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       overcommit
       pry
       rails (= 6.0.0.rc1)
-      rake (~> 12.0)
+      rake (~> 13.0)
       thor
 
 GEM
@@ -180,7 +180,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
-    rake (12.3.3)
+    rake (13.0.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/ros.gemspec
+++ b/ros.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor'
   spec.add_dependency 'pry'
   spec.add_dependency 'rails', '6.0.0.rc2'
-  spec.add_dependency 'rake', '~> 12.0'
+  spec.add_dependency 'rake', '~> 13.0'
   spec.add_dependency 'bump'
   spec.add_dependency 'config', '1.7.1'
   spec.add_dependency 'bundler' #, '~> 2.0'


### PR DESCRIPTION
If we try to load the cli from a bundle that already contains other ROS pieces, we will get a conflict on rake as they all require 13.