### PR TITLE
[PW-2463] Upgrade skaffold build/deploy to comply with Skaffold V1

### DIFF
--- a/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
+++ b/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
@@ -6,10 +6,14 @@ build:
   - image: <%= @service.name %>
     context: <%= @service.context_path %>
     docker:
-      dockerfile: <%= @service.dockerfile_path %><% if @service.image.build_args %>
-      buildArgs:<% @service.image.build_args.each_pair do |name, value| %>
-        <%= name %>: <%= value.is_a?(Array) ? value.join(' ') : value %><% end; end %>
+      dockerfile: <%= @service.dockerfile_path %>
+      <%- if @service.image.build_args -%>
+      buildArgs:
+        <%- @service.image.build_args.each_pair do |name, value| -%>
+        <%= name %>: <%= value.is_a?(Array) ? value.join(' ') : value %>
+        <%- end -%>
         project: <%= @service.name %>
+      <%- end -%>
   tagPolicy:
     envTemplate:
       template: "{{.IMAGE_NAME}}:{{.IMAGE_TAG}}"
@@ -20,6 +24,9 @@ profiles:
   <%- @service.profiles.each do |profile| -%>
   <%- xname = profile.eql?('server') ? '' : "_#{profile}" -%>
   - name: <%= profile %>
+    patches:
+    - op: remove
+      path: /build
     deploy:
       helm:
         releases:


### PR DESCRIPTION
[Upgrade skaffold to v1](https://perxtechnologies.atlassian.net/browse/PW-2463)

This PR makes `ros be up` compatible with skaffold v1.
Following commands tested against skaffold v1.0.1:
`ros be up ${service}`
`ros be up ${service} -b`
`ros be build ${service}`

However, there is no backward compatibility with skaffold v0.38.0 we currently using in ros-cli. So should be merged together with following [setup repo PR](https://github.com/rails-on-services/setup/pull/10) and ros-cli image to be rebuilt.