### PR TITLE
[PW-2585] Enable horizontal pod autoscaler for service/worker profiles

### DIFF
--- a/lib/ros/be/application/cli/kubernetes.rb
+++ b/lib/ros/be/application/cli/kubernetes.rb
@@ -172,8 +172,6 @@ module Ros
                 skaffold("deploy -f #{File.basename(service_file)}#{profile_cmd}",
                          { 'REPLICA_COUNT' => replica_count })
                 errors.add("skaffold_deploy", stderr) if exit_code.positive?
-                kubectl("scale deploy #{clean_kubernetes_name(service)} --replicas=#{replica_count}")
-                errors.add("scale_#{service}", stderr) if exit_code.positive?
               end
             end
           end
@@ -230,13 +228,14 @@ module Ros
         end
 
         def stop(services)
-          generate_config if stale_config
-          services.each do |service|
-            kubectl("scale deploy #{clean_kubernetes_name(service)} --replicas=0")
-            pods(name: service).each do |pod|
-              kubectl("delete pod #{pod}")
-            end
-          end
+          STDOUT.puts "WARN: Stop command (kubectl scale deploy --replicas=0) would have no effect as pods scale managed by HPA"
+          # generate_config if stale_config
+          # services.each do |service|
+            # kubectl("scale deploy #{clean_kubernetes_name(service)} --replicas=0")
+            # pods(name: service).each do |pod|
+              # kubectl("delete pod #{pod}")
+            # end
+          # end
         end
 
         def get_credentials

--- a/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
+++ b/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
@@ -78,6 +78,10 @@ profiles:
                 <%- @service.secrets_files.each do |name| -%>
                 - <%= name %>
                 <%- end -%>
+            <%- unless profile.eql?('scheduler') %>
+            autoscaling:
+              enabled: true
+            <%- end %>
             <%- if profile.eql?('server') -%>
             bootstrap:
               enabled: true


### PR DESCRIPTION
Enable horizontal pod autoscaler for service/worker profiles.

Respective service helm chart was updated by [this commit](https://github.com/rails-on-services/helm-charts/commit/b1ed4cdb8e85ef293d151c4b985b125c2b423326) . Pls review also