### PR TITLE
PW-2457/add redis dashboards to grafana

### DIFF
--- a/lib/ros/be/infra/templates/terraform/aws/kubernetes.tf.erb
+++ b/lib/ros/be/infra/templates/terraform/aws/kubernetes.tf.erb
@@ -174,7 +174,10 @@ module "eks-cluster" {
   ]
 
   eks_map_roles      = module.iam.eks_map_roles
-  eks_extra_policies = data.template_file.aws_iam_policy_document_s3[*].rendered
+  eks_extra_policies = concat(
+    data.template_file.aws_iam_policy_document_s3[*].rendered,
+    data.template_file.aws_iam_policy_document_cloudwatch[*].rendered
+  )
   tags               = var.tags
 }
 
@@ -245,6 +248,7 @@ module "eks-resources" {
   istio_ingressgateway_alb_cert_arn = module.acm.this.arn
   kubeconfig                        = module.eks-cluster.this.kubeconfig
   vpc_id                            = module.vpc.vpc_id
+  # tags                              = var.tags
 
   enable_fluentd_gcp_logging                   = <%= infra.components.kubernetes.components.services.components.cluster_logging.config.provider == 'gcp' ? true : false %>
   fluentd_gcp_logging_service_account_json_key = var.fluentd_gcp_logging_service_account_json_key
@@ -411,6 +415,10 @@ data "template_file" "aws_iam_policy_document_s3" {
 }
 
 # Cloudwatch access
+data "template_file" "aws_iam_policy_document_cloudwatch" {
+  template = data.aws_iam_policy_document.cloudwatch.json
+}
+
 data "aws_iam_policy_document" "cloudwatch" {
   statement {
     sid = "AllowReadingMetricsFromCloudWatch"

--- a/lib/ros/be/infra/templates/terraform/aws/kubernetes.tf.erb
+++ b/lib/ros/be/infra/templates/terraform/aws/kubernetes.tf.erb
@@ -185,12 +185,12 @@ output "eks" {
 # Below two depends_on `module.eks-cluster`. Both may cause circular dependancy under certain circumstances
 # Temporary comment both `depends_on` if weird cycle error raised during `apply`
 data "aws_eks_cluster" "cluster" {
-  depends_on = [module.eks-cluster]
+  # depends_on = [module.eks-cluster]
   name = local.cluster_name
 }
 
 data "aws_eks_cluster_auth" "cluster-auth" {
-  depends_on = [module.eks-cluster]
+  # depends_on = [module.eks-cluster]
   name       = local.cluster_name
 }
 
@@ -386,6 +386,8 @@ output "elasticache-redis-<%= key %>" {
 <% end -%>
 
 # EKS extra policy templates
+
+# S3 Buckets access
 data "aws_iam_policy_document" "s3_buckets" {
   statement {
     actions   = ["s3:GetObject", "s3:PutObject"]
@@ -405,6 +407,41 @@ data "template_file" "aws_iam_policy_document_s3" {
   vars = {
     bucket_name = local.s3_buckets[count.index]
     origin_path = "/"
+  }
+}
+
+# Cloudwatch access
+data "aws_iam_policy_document" "cloudwatch" {
+  statement {
+    sid = "AllowReadingMetricsFromCloudWatch"
+
+    actions = [
+      "cloudwatch:DescribeAlarmsForMetric",
+      "cloudwatch:ListMetrics",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:GetMetricData"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AllowReadingTagsInstancesRegionsFromEC2"
+
+    actions = [
+      "ec2:DescribeTags",
+      "ec2:DescribeInstances",
+      "ec2:DescribeRegions"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AllowReadingResourcesForTags"
+
+    actions   = ["tag:GetResources"]
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
This PR creates and assign IAM policy to list/get cloudwatch mentrics by cluster nodes. Used for Grafana Cloudwatch provider.