### PR TITLE
[PW-2796] Add --atomic flag to helm install/upgrade. Add --only-infra cli command flag

### DIFF
--- a/lib/ros/be/application/cli.rb
+++ b/lib/ros/be/application/cli.rb
@@ -136,6 +136,7 @@ module Ros
         option :shell, type: :boolean, aliases: '--sh', desc: 'Connect to service shell after starting'
         option :skip, type: :boolean, aliases: '--skip', desc: 'Skip starting services (just initialize cluster)'
         option :skip_infra, type: :boolean, aliases: '--skip-infra', desc: 'Skip deploy infra services'
+        option :only_infra, type: :boolean, aliases: '--only-infra', desc: 'Launch only infra related services and jobs'
         def up(*services)
           command = context(options)
           command.up(services)

--- a/lib/ros/be/application/cli/kubernetes.rb
+++ b/lib/ros/be/application/cli/kubernetes.rb
@@ -40,7 +40,6 @@ module Ros
 
         # TODO: Add ability for fail fast
         def up(services)
-          #@services = services.empty? ? enabled_services : services
           @platform_services = []
           @infra_services = []
 
@@ -56,15 +55,19 @@ module Ros
           end
 
           # No services specified - launch whole app stack
-          if @platform_services.empty? and @infra_services.empty?
+          if @platform_services.empty? && @infra_services.empty? && !options.only_infra
             STDOUT.puts "No specific service specified, deploy all enabled services"
             @platform_services = enabled_services
             @infra_services = enabled_application_services
+          # Launch all infra services and jobs. Useful for new environments to make sure infra is up and running before deploy any services
+          elsif @platform_services.empty? && @infra_services.empty? && options.only_infra
+            STDOUT.puts "De[ploying infra services only"
+            @infra_services = enabled_application_services
           # app service(s) specified - launch app and ensure required infra services are up and running
-          elsif not @platform_services.empty? and @infra_services.empty?
+          elsif !@platform_services.empty? && @infra_services.empty?
             @infra_services = enabled_application_services
           # infra service(s) specified - force update
-          elsif @platform_services.empty? and not @infra_services.empty?
+          elsif @platform_services.empty? && !@infra_services.empty?
             @force_infra_deploy = true
           end
           generate_config if stale_config

--- a/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
+++ b/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
@@ -29,6 +29,9 @@ profiles:
       path: /build
     deploy:
       helm:
+        flags:
+          install: ['--atomic']
+          upgrade: ['--atomic']
         releases:
         - name: <%= @service.name.to_s.gsub('_', '-') %><%= xname.gsub('_', '-') %>
           chartPath: ros/service


### PR DESCRIPTION
`--atomic` flag to let helm roll back failed deployment install/upgrade
`--only-infra`  flag to be able launch only infra services for new deployments, so services bootstrap jobs won't fail if infra not in ready state yet.