### PR TITLE
[PW-2966] Split kafka-connect BQ connectors by service name

### DIFF
--- a/lib/ros/be/application/services/templates/jobs/fluentd/kafka-topic-creation-job.yml.erb
+++ b/lib/ros/be/application/services/templates/jobs/fluentd/kafka-topic-creation-job.yml.erb
@@ -11,7 +11,8 @@ spec:
     spec:
       restartPolicy: OnFailure
       containers:
-        - name: create-topic
+        <%- @service.kafka_topics.each do |svc, topics| -%>
+        - name: create-topics-<%= svc.to_s %>
           image: confluentinc/cp-kafka:5.3.0
           command:
             - bash
@@ -30,7 +31,7 @@ spec:
               <%- end -%>
               EOT
 
-              topics=(<%= @service.kafka_topics.join(" ") %>)
+              topics=(<%= topics.join(" ") %>)
               for topic in ${topics[@]}; do
                 if kafka-topics --bootstrap-server <%= @service.kafka.bootstrap_servers %> --command-config ./config --list | grep "^${topic}$" ; then
                   echo "Topic ${topic} already exist, nothing to do"
@@ -43,3 +44,4 @@ spec:
                   --replication-factor <%= @service.kafka.topic_replication_factor || 1 %>
                 fi
               done
+        <%- end -%>

--- a/lib/ros/be/application/services/templates/jobs/kafka-connect/connector-provision-job.yml.erb
+++ b/lib/ros/be/application/services/templates/jobs/kafka-connect/connector-provision-job.yml.erb
@@ -10,22 +10,23 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       restartPolicy: OnFailure
-      initContainers:
+      containers:
         <%- @service.kafka_connect.connectors.each do |name, config| -%>
+        <%- if config.type == 'bigquery' -%>
+        <%- @service.cloudevents_subjects.each do |svc, topics| -%>
         - image: gcr.io/cloud-builders/curl
-          name: <%= name %>
+          name: <%= name %>-<%= svc.to_s %>
           command:
             - curl
             - -X
             - PUT
-            - http://kafka-connect-<%= @service.current_feature_set %>:8083/connectors/<%= name %>-<%= @service.current_feature_set %>/config
+            - http://kafka-connect-<%= @service.current_feature_set %>:8083/connectors/<%= name %>-<%= @service.current_feature_set %>-<%= svc.to_s %>/config
             - -H
             - "Content-Type: application/json"
             - -H
             - "Accept: application/json"
             - -d
             - >
-              <%- if config.type == 'bigquery' -%>
               {
                 "connector.class": "com.wepay.kafka.connect.bigquery.BigQuerySinkConnector",
                 "autoUpdateSchemas": "true",
@@ -33,7 +34,7 @@ spec:
                 "autoCreateTables": "true",
                 "sanitizeTopics": "true",
                 "tasks.max": "<%= config.tasks ? config.tasks : 2 %>",
-                "topics": "<%= @service.cloudevents_subjects.join(',') %>",
+                "topics": "<%= topics.join(',') %>",
                 "schemaRegistryLocation": "http://kafka-schema-registry:8081",
                 "topicsToTables": "(\\w+)\\.(\\w+)=$1_$2",
                 "project": "<%= config.project %>",
@@ -42,7 +43,8 @@ spec:
                 "schemaRetriever": "com.wepay.kafka.connect.bigquery.schemaregistry.schemaretriever.SchemaRegistrySchemaRetriever",
                 "key.converter": "org.apache.kafka.connect.storage.StringConverter"
               }
-              <%- end -%>
+        <%- end -%>
+        <%- end -%>
         <%- if config.type == 'bigquery' -%>
         - image: google/cloud-sdk:alpine
           name: <%= name %>-create-bq-dataset
@@ -66,10 +68,6 @@ spec:
               mountPath: /etc/google/auth
         <%- end -%>
         <%- end -%>
-      containers:
-        - image: busybox:latest
-          name: echo
-          command: ['sh', '-c', 'echo Connectors created. Check above logs!']
       volumes:
         - name: gcp-jsonkey
           secret:


### PR DESCRIPTION
This PR makes kafka-connect BigQuery connectors separated by service name.
In current setup there are 82 topics processed by single connector, one topic failure brings down whole kafka-to-BigQuery pipeline.