### PR TITLE
Postgres skaffold - use official bitnami image

### DIFF
--- a/lib/ros/be/application/services/templates/skaffold/postgres.yml.erb
+++ b/lib/ros/be/application/services/templates/skaffold/postgres.yml.erb
@@ -14,7 +14,6 @@ deploy:
               app.kubernetes.io/component: database
               app.kubernetes.io/part-of: application-services
           image:
-            repository: mdillon/postgis
             tag: 10
           fullnameOverride: postgres
           postgresqlDataDir: /data/pgdata
@@ -34,3 +33,5 @@ deploy:
             requests:
               cpu: 0.5
               memory: 1.5Gi
+          postgresqlExtendedConf:
+            max_connections: 200


### PR DESCRIPTION
Current official postgres chart installs PostGIS extensions by default.
We don't need to use 3rd party docker image for that anymore, as it is outdated and uses it's own config files that we cannot override with stable helm chart.



