### PR TITLE
Update skaffold templates

### DIFF
--- a/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
+++ b/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
@@ -133,14 +133,16 @@ profiles:
                       values:
                       - spot
               podAntiAffinity:
-                requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchExpressions:
-                    - key: app.kubernetes.io/name
-                      operator: In
-                      values:
-                      - <%= @service.name.to_s.gsub('_', '-') %><%= xname.gsub('_', '-') %>
-                  topologyKey: kubernetes.io/hostname
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values:
+                        - <%= @service.name.to_s.gsub('_', '-') %><%= xname.gsub('_', '-') %>
+                    topologyKey: kubernetes.io/hostname
             tolerations:
             - key: spotInstance
               operator: Exists

--- a/lib/ros/be/application/services/templates/skaffold/kafka-connect.yml.erb
+++ b/lib/ros/be/application/services/templates/skaffold/kafka-connect.yml.erb
@@ -17,6 +17,9 @@ deploy:
           podLabels:
             app.kubernetes.io/name: kafka-connect
             app.kubernetes.io/part-of: application-services
+          podAnnotations:
+            prometheus.io/scheme: http
+            prometheus.io/path: /metrics
           ## Kafka Connect JVM Heap Option
           heapOptions: "-Xms1024M -Xmx1024M"
           resources:

--- a/lib/ros/be/application/services/templates/skaffold/kafka-schema-registry.yml.erb
+++ b/lib/ros/be/application/services/templates/skaffold/kafka-schema-registry.yml.erb
@@ -18,6 +18,9 @@ deploy:
           podLabels:
             app.kubernetes.io/name: kafka-schema-registry
             app.kubernetes.io/part-of: application-services
+          podAnnotations:
+            prometheus.io/scheme: http
+            prometheus.io/path: /metrics
           kafka:
             <%- if @service.kafka.security_protocol == "SASL_SSL" -%>
             bootstrapServers: "SASL_SSL://<%= @service.kafka.bootstrap_servers %>"


### PR DESCRIPTION
* Set application service template podAntiAffinity to `preferred`.
This will address the case when auto-scaler wasn't able to schedule new pods. With `required` podAntiAffinity we basically restricted by current number of running nodes 

* Set podAnnotations to kafka services to allow Prometheus successfully scrape metrics.