### PR TITLE
Fix rails path for docker-composer

### DIFF
--- a/lib/ros/be/application/cli/instance.rb
+++ b/lib/ros/be/application/cli/instance.rb
@@ -201,7 +201,7 @@ module Ros
           migration_file = "#{application.compose_dir}/#{name}-migrated"
           return true if File.exist?(migration_file) unless options.seed
           FileUtils.rm(migration_file) if File.exist?(migration_file)
-          if success = compose("run --rm #{name} rails #{prefix}ros:db:reset:seed")
+          if success = compose("run --rm #{name} bin/rails #{prefix}ros:db:reset:seed")
             FileUtils.touch(migration_file)
             remove_cache('iam') if name.eql?('iam')
           else


### PR DESCRIPTION
following error thrown by CircleCi recently:
`Error response from daemon: OCI runtime create failed: container_linux.go:344: starting container process caused "exec: \"rails\": executable file not found in $PATH": unknown`

This PR should fix that