### PR TITLE
Separate avro schemas and database migrations in two jobs

### DIFF
--- a/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
+++ b/lib/ros/be/application/platform/templates/skaffold/service.yml.erb
@@ -94,7 +94,12 @@ profiles:
             hook:
               upgradeMigration:
                 enabled: true
-                command: ["bundle", "exec", "rails", "<% if @service.is_ros_service %>app:<% end %>db:migrate"<% if services_components[:"kafka-schema-registry"]&.config&.enabled%>, "<% if @service.is_ros_service %>app:<% end %>ros:avro:register"<% end %>]
+                command: ["bundle", "exec", "rails", "<% if @service.is_ros_service %>app:<% end %>db:migrate"]
+              <%- if services_components[:"kafka-schema-registry"]&.config&.enabled -%>
+              avroMigration:
+                enabled: true
+                command: ["bundle", "exec", "rails", "<% if @service.is_ros_service %>app:<% end %>ros:avro:register"]
+              <%- end -%>
             <%- else -%>
             service:
               enabled: false
@@ -104,6 +109,8 @@ profiles:
               enabled: false
             hook:
               upgradeMigration:
+                enabled: false
+              avroMigration:
                 enabled: false
             <%- end -%>
             metrics:

--- a/lib/ros/be/infra/templates/terraform/aws/kubernetes.tf.erb
+++ b/lib/ros/be/infra/templates/terraform/aws/kubernetes.tf.erb
@@ -357,7 +357,7 @@ module "rds-<%= key %>" {
 
   engine                          = "aurora-postgresql"
   engine_version                  = "10.7"
-  instance_type                   = "db.r5.large"
+  instance_type                   = "<%= infra.components.databases.config.clusters.default.instance_type %>"
   performance_insights_enabled    = true
   vpc_id                          = module.vpc.vpc_id
   subnets                         = module.vpc.database_subnets


### PR DESCRIPTION
This is to separate avro schemas migration job from DB migration job.
Should be easier to debug migrations. Faulty schemas won't affect DB migration and vice versa.

Also added variable into `kubernetes.tf.erb` to respect RDS instance size from config.

Update to service helm-chart is [here](https://github.com/rails-on-services/helm-charts/commit/ac0f7fa227de6f2c666c5086fa79252cc2a07704)