### PR TITLE
rails: disable gssencmode

### DIFF
--- a/lib/ros/be/application/platform/rails/core/rails/templates/config/database.yml.tt
+++ b/lib/ros/be/application/platform/rails/core/rails/templates/config/database.yml.tt
@@ -14,10 +14,14 @@ default: &default
 development:
   <<: *default
   database: <%= @database_prefix %>_development
+  # https://www.postgresql.org/message-id/93f7379b-2e2f-db0c-980e-07ebd5de92ff%40crunchydata.com
+  gssencmode: disable
 
 test:
   <<: *default
   database: <%= @database_prefix %>_test
+  # https://www.postgresql.org/message-id/93f7379b-2e2f-db0c-980e-07ebd5de92ff%40crunchydata.com
+  gssencmode: disable
 
 production:
   <<: *default


### PR DESCRIPTION
On darwin, some of the services will fail when running `rails console` unless
gssencmode is disabled.

https://www.postgresql.org/message-id/93f7379b-2e2f-db0c-980e-07ebd5de92ff%40crunchydata.com

@rjayroach, you probably want to do this for cnfs as well.